### PR TITLE
Feat: 검색 시 텍스트만, 사진 촬영 시 이미지와 텍스트 동시 제공 기능추가

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -22,6 +22,7 @@ const SearchBar = () => {
   };
 
   const handleCancel = () => {
+    // 취소 버튼
     setFormData({
       title: "",
       price: "",
@@ -37,6 +38,21 @@ const SearchBar = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault(); // 기본 폼 제출 동작 방지
+
+    // 유효성 검사 (추가)
+    if (!formData.title.trim()) {
+      alert("상품명을 입력해주세요.(필수)");
+      return;
+    } else if (!formData.price.trim()) {
+      alert("가격을 입력해주세요.(필수)");
+      return;
+    }
+
+    if (formData.price && isNaN(Number(formData.price))) {
+      alert("가격은 숫자로 입력해주세요.");
+      return;
+    }
+
     console.log("API 요청 데이터:", postData); // 요청 데이터 확인
 
     try {
@@ -49,9 +65,13 @@ const SearchBar = () => {
       const items = res.data.items || [];
 
       //compareItem 페이지로 백에서 api 로 받아온 items을 props로 넘기기
-      navigate("/compareItem", { state: { items } });
+      navigate("/compareItem", {
+        state: { items, searchQuery: formData.title },
+      });
     } catch (err) {
       console.log("오류가 발생");
+      console.error("API 요청 실패:", err.response?.data || err.message);
+      alert("상품 검색에 실패했습니다. 다시 시도해주세요.");
     }
   };
 
@@ -84,7 +104,7 @@ const SearchBar = () => {
           <input
             type="text"
             name="price"
-            placeholder="가격 (선택)"
+            placeholder="가격"
             value={formData.price}
             onChange={handleChange}
           />

--- a/src/pages/PicturePage.js
+++ b/src/pages/PicturePage.js
@@ -4,55 +4,65 @@ import "../style/PicturePage.css";
 import axios from "axios";
 
 const PicturePage = () => {
-    const location = useLocation();
-    const navigate = useNavigate();
-    const photo = location.state?.photo;
+  const location = useLocation();
+  const navigate = useNavigate();
+  const photo = location.state?.photo;
 
-    const handleUpload = async () => {
-        try {
-            // base64 → Blob 변환
-            const blob = await fetch(photo).then(res => res.blob());
-            const formData = new FormData();
-            formData.append("file", blob, "image.png");
+  const handleUpload = async () => {
+    try {
+      // base64 → Blob 변환
+      const blob = await fetch(photo).then((res) => res.blob());
+      const formData = new FormData();
+      formData.append("file", blob, "image.png");
 
-            // FastAPI로 이미지 전송
-            const response = await axios.post( process.env.REACT_APP_FASTAPI_URL + "/analyze/", formData, {
-                headers: {
-                    "Content-Type": "multipart/form-data",
-                },
-            });
-
-            const result = response.data;
-            console.log("Spring에서 받은 결과:", result);
-
-            navigate("/compareItem", { state: { items: result.items } });
-
-        } catch (error) {
-            console.error("에러 발생:", error);
-            const message =
-                error.response?.data?.message || "이미지 업로드 중 오류가 발생했습니다.";
-            alert("분석 실패: " + message);
+      // FastAPI로 이미지 전송
+      const response = await axios.post(
+        process.env.REACT_APP_FASTAPI_URL + "/analyze/",
+        formData,
+        {
+          headers: {
+            "Content-Type": "multipart/form-data",
+          },
         }
-    };
+      );
 
-    if (!photo) {
-        return <p>사진이 없습니다. 다시 촬영해주세요.</p>;
+      const result = response.data;
+      console.log("Spring에서 받은 결과:", result);
+
+      navigate("/compareItem", {
+        state: {
+          items: result.items,
+          searchQuery: result.title,
+          receiptImage: photo,
+        },
+      });
+    } catch (error) {
+      console.error("에러 발생:", error);
+      const message =
+        error.response?.data?.message ||
+        "이미지 업로드 중 오류가 발생했습니다.";
+      alert("분석 실패: " + message);
     }
+  };
 
-    return (
-        <div className="picture-page">
-            <h2>촬영한 이미지</h2>
-            <img src={photo} alt="Captured" className="captured-image" />
+  if (!photo) {
+    return <p>사진이 없습니다. 다시 촬영해주세요.</p>;
+  }
 
-            <button className="camera-button" onClick={() => navigate("/camera")}>
-                ↩️ 다시 촬영
-            </button>
+  return (
+    <div className="picture-page">
+      <h2>촬영한 이미지</h2>
+      <img src={photo} alt="Captured" className="captured-image" />
 
-            <button className="camera-button" onClick={handleUpload}>
-                확인
-            </button>
-        </div>
-    );
+      <button className="camera-button" onClick={() => navigate("/camera")}>
+        ↩️ 다시 촬영
+      </button>
+
+      <button className="camera-button" onClick={handleUpload}>
+        확인
+      </button>
+    </div>
+  );
 };
 
 export default PicturePage;


### PR DESCRIPTION
## 연관된 이슈

## 작업 내용

> 홈화면에서 검색할 경우, 검색 상품명만 출력되고 카메라로 가격표를 찍어 올리는 경우에는 상품명 + 가격표 이미지가 동시에 보이게 하는 기능 추가
(+ 추가적으로 홈 화면에서 검색할 때, 상품명 혹은 가격 안적을 경우, 검색 못하게 하는 기능도 추가함)

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/6f0bb039-1219-4e2c-a4d1-4964f10890a5)
![image](https://github.com/user-attachments/assets/7ad3d3ee-2a38-4b80-aa7d-beab269237e5)
![image](https://github.com/user-attachments/assets/587d0c0c-981a-4229-b70b-ecbefb12771d)


## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 카메라로 찍었을 경우를 테스트 해보려고 웹캠으로 해봤는데 인식을 못해서 아직 확인을 못해봤음 한번 확인해보고 안되면 반환 부탁드립니다.
