### PR TITLE
Feat: 장바구니 상품 수량 추가 및 오프라인/매장 상품과 온라인 가격 비교

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,8 @@ import PicturePage from "./pages/PicturePage";
 import ComparePage from "./pages/ComparePage";
 import CartList from "./pages/CartList";
 import CartDetailList from "./pages/cartDetailList";
+import SavedAmountPage from "./pages/SavedAmountPage";
+import CheckListPage from "./pages/CheckListPage";
 
 
 import HistoryPage from "./pages/HistoryPage";
@@ -29,7 +31,7 @@ const App = () => {
 
         <Route path="/camera" element={<CameraPage />} />
         <Route path="/picture" element={<PicturePage />} />
-        <Route path="/compareitem" element={<ComparePage />} />
+        <Route path="/compareItem" element={<ComparePage />} />
         <Route path="/cart" element={<CartList />} />
 
         <Route path="/cartDetailList" element={<CartDetailList />} />
@@ -38,7 +40,8 @@ const App = () => {
 
         <Route path="/history" element={<HistoryPage />} />
         <Route path="/history/:cartId" element={<CartDetailPage />} />
-
+        <Route path="/saved-amounts" element={<SavedAmountPage />} />
+        <Route path="/checkListPage" element={<CheckListPage />} />
       </Routes>
     </Router>
   );

--- a/src/components/BottomNav.js
+++ b/src/components/BottomNav.js
@@ -11,10 +11,10 @@ const BottomNav = () => {
   return (
     <nav className="bottom-nav">
       <button
-        className={isActive("/history") ? "active" : ""}
-        onClick={() => navigate("/history")}
+        className={isActive("/checkListPage") ? "active" : ""}
+        onClick={() => navigate("/checkListPage")}
       >
-        ✅<br />기록
+        ✅<br /> 체크리스트
       </button>
       <button
         className={isActive("/camera") ? "active" : ""}

--- a/src/components/CartItem.js
+++ b/src/components/CartItem.js
@@ -1,0 +1,102 @@
+import React from "react";
+import "../style/CartItem.css";
+
+const CartItem = ({
+                      item,
+                      checked,
+                      onCheckboxChange,
+                      onIncrease,
+                      onDecrease,
+                      showQuantityControls = true,
+                      showCheckbox = true
+                  }) => {
+
+    const savedAmount = item.compareItemPrice > 0
+        ? (item.compareItemPrice - item.price) * item.quantity
+        : 0;
+
+    return (
+        <div key={item.id} className="cart-item">
+            {/* 이미지 */}
+            <div className="cart-item-image-container">
+                <img
+                    src={item.image}
+                    alt={item.title}
+                    className="cart-item-image"
+                />
+            </div>
+
+            {/* 상세 */}
+            <div className="cart-item-details">
+                <h3 className="item-title">{item.title}</h3>
+                <p className="item-brand">{item.brand}</p>
+                <p className="item-store">{item.mallName}</p>
+
+                {/* 수량 + 가격 */}
+                {showQuantityControls && (
+                    <div className="item-bottom">
+                        <div className="quantity-control">
+                            <button className="quantity-btn" onClick={() => onDecrease(item.id)}>-</button>
+                            <span className="quantity-number">{item.quantity}</span>
+                            <button className="quantity-btn" onClick={() => onIncrease(item.id)}>+</button>
+                        </div>
+                        <div>
+                            <p className="item-price">
+                                ₩{(item.price * item.quantity).toLocaleString()}
+                                <span className="item-unit-price"> ({item.price.toLocaleString()}원 × {item.quantity})</span>
+                            </p>
+                            {/* 비교가 표시 */}
+                            {item.compareItemPrice > 0 && (
+                                <p className="compare-price">
+                                    비교가 ₩{(item.compareItemPrice * item.quantity).toLocaleString()}
+                                </p>
+                            )}
+                            {/* 절약금액 표시 */}
+                            {savedAmount > 0 && (
+                                <p className="saved-amount">
+                                    💸 {savedAmount.toLocaleString()}원 절약했어요!
+                                </p>
+                            )}
+                        </div>
+                    </div>
+                )}
+
+                {!showQuantityControls && (
+                    <div>
+                        <p className="item-price">
+                            ₩{(item.price * item.quantity).toLocaleString()}
+                            <span className="item-unit-price"> ({item.price.toLocaleString()}원 × {item.quantity})</span>
+                        </p>
+                        <div className="compare-saved-row">
+                            {item.compareItemPrice > 0 && (
+                                <span className="compare-price">
+                                      비교가 ₩{(item.compareItemPrice * item.quantity).toLocaleString()}
+                                    </span>
+                            )}
+                            {savedAmount > 0 && (
+                                <span className="saved-amount">
+                                      💸 {savedAmount.toLocaleString()}원 절약했어요!
+                                    </span>
+                            )}
+                        </div>
+
+                    </div>
+                )}
+            </div>
+
+            {/* 체크박스 */}
+            {showCheckbox && (
+                <div className="item-actions">
+                    <div
+                        className={`check-icon ${checked ? "checked" : ""}`}
+                        onClick={() => onCheckboxChange(item.id)}
+                    >
+                        {checked && <span>✓</span>}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default CartItem;

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -63,10 +63,11 @@ const SearchBar = () => {
 
       console.log("API 응답 데이터:", res.data); // 응답 데이터 확인용
       const items = res.data.items || [];
+      const compareItemPrice = res.data.compareItem.price || null;
 
       //compareItem 페이지로 백에서 api 로 받아온 items을 props로 넘기기
       navigate("/compareItem", {
-        state: { items, searchQuery: formData.title },
+        state: { items, compareItemPrice, searchQuery: formData.title },
       });
     } catch (err) {
       console.log("오류가 발생");

--- a/src/pages/CameraPage.js
+++ b/src/pages/CameraPage.js
@@ -24,7 +24,6 @@ const CameraPage = () => {
 
     return () => {
       if (videoRef.current?.srcObject) {
-        // eslint-disable-next-line react-hooks/exhaustive-deps
         videoRef.current.srcObject.getTracks().forEach((track) => track.stop());
       }
     };
@@ -47,40 +46,71 @@ const CameraPage = () => {
     canvas.height = cropHeight;
 
     ctx.drawImage(
-      video,
-      cropX,
-      cropY,
-      cropWidth,
-      cropHeight,
-      0,
-      0,
-      cropWidth,
-      cropHeight
+        video,
+        cropX,
+        cropY,
+        cropWidth,
+        cropHeight,
+        0,
+        0,
+        cropWidth,
+        cropHeight
     );
 
     const image = canvas.toDataURL("image/png");
     navigate("/picture", { state: { photo: image } });
   };
 
+  const handleFileChange = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const img = new Image();
+      img.onload = () => {
+        const canvas = canvasRef.current;
+        const ctx = canvas.getContext("2d");
+
+        canvas.width = img.width;
+        canvas.height = img.height;
+        ctx.drawImage(img, 0, 0);
+
+        const image = canvas.toDataURL("image/png");
+        navigate("/picture", { state: { photo: image } });
+      };
+      img.src = event.target.result;
+    };
+    reader.readAsDataURL(file);
+  };
+
   return (
-    <div className="camera-wrapper">
-      <header>
-        <HomeButton />
-      </header>
+      <div className="camera-wrapper">
+        <header>
+          <HomeButton />
+        </header>
 
-      <h2>가격표 촬영</h2>
-      <div className="camera-container">
-        <video ref={videoRef} autoPlay playsInline className="camera-video" />
-        <div className="camera-frame" />
+        <h2>가격표 촬영</h2>
+        <div className="camera-container">
+          <video ref={videoRef} autoPlay playsInline className="camera-video" />
+          <div className="camera-frame" />
+        </div>
+
+        <button onClick={capture} className="camera-button">
+          촬영하기
+        </button>
+
+        {/* 파일 업로드 input */}
+        <input
+            type="file"
+            accept="image/*"
+            onChange={handleFileChange}
+            className="camera-file-input"
+        />
+
+        <canvas ref={canvasRef} style={{ display: "none" }} />
+        <BottomNav />
       </div>
-
-      <button onClick={capture} className="camera-button">
-        촬영하기
-      </button>
-      <canvas ref={canvasRef} style={{ display: "none" }} />
-
-      <BottomNav />
-    </div>
   );
 };
 

--- a/src/pages/CartDetailPage.js
+++ b/src/pages/CartDetailPage.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import api from "../api";
 import "../style/CartList.css";
+import CartItem from "../components/CartItem";
 
 const CartDetailPage = () => {
   const { cartId } = useParams();
@@ -21,38 +22,72 @@ const CartDetailPage = () => {
     fetchCartItems();
   }, [cartId]);
 
+  const calculateTotalPrice = () => {
+    return items.reduce((total, item) => total + (item.price * item.quantity), 0);
+  };
+
+  const calculateTotalComparePrice = () => {
+    return items.reduce((total, item) => {
+      if (item.compareItemPrice > 0) {
+        return total + (item.compareItemPrice * item.quantity);
+      }
+      return total;
+    }, 0);
+  };
+
+  const calculateTotalSaved = () => {
+    return items.reduce((total, item) => {
+      if (item.compareItemPrice > 0) {
+        return total + ((item.compareItemPrice - item.price) * item.quantity);
+      }
+      return total;
+    }, 0);
+  };
+
   const goBack = () => {
     navigate("/history");
   };
 
   return (
-    <div className="cart-container">
-      <div className="back-button-container">
-        <button className="back-button" onClick={goBack}>
-          ← 장바구니 기록으로
-        </button>
+      <div className="cart-container">
+        <div className="back-button-container">
+          <button className="back-button" onClick={goBack}>
+            ← 장바구니 기록으로
+          </button>
+        </div>
+
+        <h1 className="cart-title">장바구니 상세</h1>
+
+        {items.length === 0 ? (
+            <div className="empty-cart">해당 장바구니에는 상품이 없습니다.</div>
+        ) : (
+            <>
+              {items.map((item) => (
+                  <CartItem
+                      key={item.id}
+                      item={item}
+                      showQuantityControls={false}
+                      showCheckbox={false}
+                  />
+              ))}
+
+              {/* 하단 총 합계 + 비교가 + 절약금액 표시 */}
+              <div className="order-footer">
+                <div className="order-info">
+                  <div className="order-price">
+                    총 합계: ₩{calculateTotalPrice().toLocaleString()}
+                  </div>
+                  <div className="order-compare-price">
+                    비교가: ₩{calculateTotalComparePrice().toLocaleString()}
+                  </div>
+                  <div className="order-saved">
+                    절약한 금액: ₩{calculateTotalSaved().toLocaleString()}
+                  </div>
+                </div>
+              </div>
+            </>
+        )}
       </div>
-
-      <h1 className="cart-title">장바구니 상세</h1>
-
-      {items.length === 0 ? (
-        <div className="empty-cart">해당 장바구니에는 상품이 없습니다.</div>
-      ) : (
-        items.map((item) => (
-          <div key={item.id} className="cart-item">
-            <div className="cart-item-image-container">
-              <img src={item.image} alt={item.title} className="cart-item-image" />
-            </div>
-            <div className="cart-item-details">
-              <h3>{item.title}</h3>
-              <p className="item-brand">{item.brand}</p>
-              <p className="item-store">{item.mallName}</p>
-              <p className="item-price">₩{item.price.toLocaleString()}</p>
-            </div>
-          </div>
-        ))
-      )}
-    </div>
   );
 };
 

--- a/src/pages/CheckListPage.js
+++ b/src/pages/CheckListPage.js
@@ -1,0 +1,16 @@
+import React, { useEffect } from "react";
+import BottomNav from "../components/BottomNav";
+
+
+const CheckListPage = () => {
+   
+    return (
+        <div className="main-container">
+           <h1>체크리스트</h1>
+
+            <BottomNav />
+        </div>
+    );
+};
+
+export default CheckListPage;

--- a/src/pages/ComparePage.js
+++ b/src/pages/ComparePage.js
@@ -11,6 +11,7 @@ const ComparePage = ({ product }) => {
   const sourceType = location.state?.sourceType || "search"; // 데이터 출처 구분:  "photo"  또는 "검색" (추가)
   const productName = location.state?.searchQuery; // 받아온 검색어 (추가)
   const takenPicture = location.state?.receiptImage; // 찍은 가격표 사진
+  const compareItemPrice = location.state?.compareItemPrice ?? 0;// 비교 상품 정보
 
   const [products, setProducts] = useState([]);
   const [checkedItems, setCheckedItems] = useState([]);
@@ -90,6 +91,8 @@ const ComparePage = ({ product }) => {
       mallName: selectedItem.mallName ?? "",
       brand: selectedItem.brand ?? "",
       volume: selectedItem.volume ?? "",
+      quantity: 1,
+      compareItemPrice: compareItemPrice,
     };
 
     console.log("🛒 장바구니에 담을 상품:", onlineItemDto);

--- a/src/pages/HistoryPage.js
+++ b/src/pages/HistoryPage.js
@@ -40,17 +40,19 @@ const HistoryPage = () => {
       <h1 className="cart-title">장바구니 기록</h1>
 
       {cartList.length === 0 ? (
-        <div className="empty-cart">기록된 장바구니가 없습니다.</div>
+          <div className="empty-cart">기록된 장바구니가 없습니다.</div>
       ) : (
-        cartList.map((cart) => (
-          <div
-            key={cart.cartId}
-            className="cart-history-summary hover-underline" // ✅ 새 클래스 추가
-            onClick={() => goToDetailPage(cart.cartId)}
-          >
-            🛒 {cart.name} - {formatDate(cart.createdAt)}
-          </div>
-        ))
+          [...cartList]
+              .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt)) // 최신순 정렬
+              .map((cart) => (
+                  <div
+                      key={cart.cartId}
+                      className="cart-history-summary hover-underline"
+                      onClick={() => goToDetailPage(cart.cartId)}
+                  >
+                    🛒 {cart.name} - {formatDate(cart.createdAt)}
+                  </div>
+              ))
       )}
     </div>
   );

--- a/src/pages/MyPage.js
+++ b/src/pages/MyPage.js
@@ -25,6 +25,7 @@ import "react-toastify/dist/ReactToastify.css";
 
 const MyPage = () => {
   const [user, setUser] = useState(null);
+  const [thisMonthSaved, setThisMonthSaved] = useState(0);
   const [loading, setLoading] = useState(true);
   const [chartType, setChartType] = useState("line");
   const [showChartOptions, setShowChartOptions] = useState(false);
@@ -38,6 +39,7 @@ const MyPage = () => {
     { month: "2025.1", amount: 10000 },
     { month: "2025.2", amount: 40000 },
     { month: "2025.3", amount: 55000 },
+    { month: "2025.4", amount: thisMonthSaved.toLocaleString()},
   ];
 
   useEffect(() => {
@@ -62,9 +64,8 @@ const MyPage = () => {
         const response = await api.get("/mypage", {
           headers: { Authorization: token || "" },
         });
-        //console.log("마이페이지 데이터:", response.data);
-        //setUser(response.data.username);
         setUser(response.data.name);
+        setThisMonthSaved(response.data.thisMonthSaved); // 절약 금액
       } catch (error) {
         console.error("인증 실패:", error);
       } finally {
@@ -105,6 +106,14 @@ const MyPage = () => {
       fileInputRef.current.click();
     }
   };
+
+  const goToSavedAmountPage = () => {
+    navigate("/saved-amounts");
+  };
+
+  const goToHistoryPage = () => {
+    navigate("/history");
+  };
   
   return (
     <>
@@ -135,7 +144,7 @@ const MyPage = () => {
 
             <div className="profile-info">
               <h3>{user ?? "사용자명"}</h3>
-              <p>이번 달 아낀 금액</p>
+              <p>이번 달 아낀 금액: {thisMonthSaved.toLocaleString()}원</p>
             </div>
           </div>
 
@@ -173,7 +182,7 @@ const MyPage = () => {
 
           {/* 차트 변경 버튼 */}
           <div className="button-list">
-            <div className="mypage-button">최근 본 상품</div>
+            <div className="mypage-button" onClick={goToHistoryPage} >최근 본 상품</div>
             <div className="mypage-button chart-toggle-button" onClick={() => setShowChartOptions(!showChartOptions)}>
               테마 변경
             </div>
@@ -191,7 +200,9 @@ const MyPage = () => {
                 <span>영역 그래프</span>
               </button>
             </div>
-            <div className="mypage-button">아낀 금액 통계</div>
+            <div className="mypage-button" onClick={goToSavedAmountPage}>
+              아낀 금액 통계
+            </div>
             <div className="mypage-button">비밀번호 변경</div>
           </div>
 

--- a/src/pages/PicturePage.js
+++ b/src/pages/PicturePage.js
@@ -34,6 +34,7 @@ const PicturePage = () => {
           items: result.items,
           searchQuery: result.title,
           receiptImage: photo,
+          compareItemPrice: result.compareItem.price,
         },
       });
     } catch (error) {

--- a/src/pages/SavedAmountPage.js
+++ b/src/pages/SavedAmountPage.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import api from "../api";
+import "../style/SavedAmountPage.css";
+
+const SavedAmountPage = () => {
+    const navigate = useNavigate();
+    const [savedAmounts, setSavedAmounts] = useState([]);
+
+    useEffect(() => {
+        const fetchSavedAmounts = async () => {
+            try {
+                const token = localStorage.getItem("Authorization");
+                const response = await api.get("/mypage/saved-amounts", {
+                    headers: { Authorization: token || "" },
+                });
+                setSavedAmounts(response.data);
+            } catch (error) {
+                console.error("절약 금액 통계 불러오기 실패:", error);
+            }
+        };
+
+        fetchSavedAmounts();
+    }, []);
+
+    const goBack = () => {
+        navigate("/mypage");
+    };
+
+    return (
+        <div className="saved-page-container">
+            <h1>월별 절약 금액</h1>
+            <div className="saved-list">
+                {savedAmounts.length === 0 ? (
+                    <p>아직 절약한 기록이 없습니다.</p>
+                ) : (
+                    savedAmounts.map((item, index) => (
+                        <div key={index} className="saved-list-item">
+                            {item.month} : {item.amount.toLocaleString()}원
+                        </div>
+                    ))
+                )}
+            </div>
+
+            <button className="saved-back-button" onClick={goBack}>
+                돌아가기
+            </button>
+        </div>
+    );
+};
+
+export default SavedAmountPage;

--- a/src/style/CartItem.css
+++ b/src/style/CartItem.css
@@ -1,0 +1,53 @@
+.item-bottom {
+    display: flex;
+    align-items: center;
+    margin-top: 8px;
+    gap: 16px; /* 수량조절 버튼과 가격 사이 간격 */
+}
+
+.quantity-control {
+    display: flex;
+    align-items: center;
+}
+
+.quantity-btn {
+    width: 28px;
+    height: 28px;
+    font-size: 18px;
+    border: 1px solid #ccc;
+    background: white;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.quantity-number {
+    margin: 0 8px;
+    font-size: 14px;
+}
+
+.item-price {
+    font-size: 16px;
+    font-weight: bold;
+}
+
+.item-unit-price {
+    font-size: 12px;
+    color: #888;
+    margin-left: 4px;
+}
+
+/* 절약 강조 */
+.saved-amount {
+    margin-top: 4px;
+    font-size: 13px;
+    color: #28a745;
+    font-weight: bold;
+}
+
+.compare-price {
+    margin-top: 2px;
+    font-size: 12px;
+    text-decoration: line-through;
+    color: #555;
+}
+

--- a/src/style/CartList.css
+++ b/src/style/CartList.css
@@ -1,8 +1,9 @@
-/* 코드 문제있으면 알려주세요(김경민) */
+/* --- 기본 배경 --- */
 body {
   background-color: #f7f8fa;
 }
 
+/* --- 전체 장바구니 컨테이너 --- */
 .cart-container {
   max-width: 480px;
   margin: 0 auto;
@@ -15,9 +16,10 @@ body {
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
   overflow: hidden;
   position: relative;
-  padding-bottom: 20px;
+  padding-bottom: 80px; /* 하단 버튼 공간 확보 */
 }
 
+/* --- 홈 아이콘 (미사용시 주석처리) --- */
 .home-icon-container {
   padding: 10px;
   position: absolute;
@@ -41,9 +43,10 @@ body {
   font-size: 20px;
 }
 
+/* --- 상단 뒤로가기 / 삭제 버튼 구역 --- */
 .back-button-container {
   display: flex;
-  justify-content: space-between; /* 좌우 정렬 */
+  justify-content: space-between;
   align-items: center;
   margin-top: 25px;
   margin-bottom: 10px;
@@ -58,6 +61,10 @@ body {
   cursor: pointer;
   padding: 5px 0;
   text-decoration: underline;
+}
+
+.back-button:hover {
+  color: #000;
 }
 
 .delete-button {
@@ -75,10 +82,7 @@ body {
   background-color: #e60000;
 }
 
-.back-button:hover {
-  color: #000;
-}
-
+/* --- 타이틀 --- */
 .cart-title {
   text-align: center;
   font-size: 24px;
@@ -87,6 +91,7 @@ body {
   color: #333;
 }
 
+/* --- 사용자 메세지 --- */
 .user-message {
   text-align: center;
   margin: 15px 0;
@@ -99,11 +104,13 @@ body {
   margin: 0;
 }
 
+/* --- 장바구니 아이템 리스트 --- */
 .cart-items-list {
   padding: 0 16px;
   margin-top: 20px;
 }
 
+/* --- 빈 장바구니 메시지 --- */
 .empty-cart {
   text-align: center;
   font-size: 16px;
@@ -111,6 +118,7 @@ body {
   margin: 30px 0;
 }
 
+/* --- 장바구니 아이템 개별 애니메이션 --- */
 @keyframes fadeInUp {
   0% {
     opacity: 0;
@@ -122,8 +130,10 @@ body {
   }
 }
 
+/* --- 장바구니 아이템 --- */
 .cart-item {
   display: flex;
+  justify-content: space-between;
   border-bottom: 1px solid #eee;
   padding: 15px 0;
   margin-bottom: 15px;
@@ -131,22 +141,14 @@ body {
   animation: fadeInUp 0.6s ease-in-out forwards;
 }
 
-.cart-item:nth-child(1) {
-  animation-delay: 0.2s;
-}
-.cart-item:nth-child(2) {
-  animation-delay: 0.4s;
-}
-.cart-item:nth-child(3) {
-  animation-delay: 0.6s;
-}
-.cart-item:nth-child(4) {
-  animation-delay: 0.8s;
-}
-.cart-item:nth-child(5) {
-  animation-delay: 1s;
-}
+/* 아이템 등장 시간 다르게 */
+.cart-item:nth-child(1) { animation-delay: 0.2s; }
+.cart-item:nth-child(2) { animation-delay: 0.4s; }
+.cart-item:nth-child(3) { animation-delay: 0.6s; }
+.cart-item:nth-child(4) { animation-delay: 0.8s; }
+.cart-item:nth-child(5) { animation-delay: 1s; }
 
+/* --- 상품 이미지 컨테이너 --- */
 .cart-item-image-container {
   width: 80px;
   height: 80px;
@@ -165,6 +167,7 @@ body {
   object-fit: cover;
 }
 
+/* --- 상품 정보 --- */
 .cart-item-details {
   flex: 1;
   display: flex;
@@ -191,35 +194,41 @@ body {
   margin-top: 8px;
 }
 
-.complete-button {
-  width: 90%;
-  margin: 25px auto 0;
-  padding: 12px 20px;
-  background-color: #007bff;
-  color: white;
-  border: none;
-  border-radius: 8px;
-  font-size: 16px;
-  cursor: pointer;
-  text-align: center;
-  font-weight: bold;
-  transition: background-color 0.3s;
-}
-
-.complete-button:hover {
-  background-color: #0056d2;
-}
-
-/* .debug-info {
-  margin: 15px 16px;
-  padding: 10px;
-  background-color: #f8f8f8;
-  border: 1px solid #ddd;
-  border-radius: 4px;
+.item-unit-price {
   font-size: 12px;
-  color: #666;
-} */
+  color: #888;
+  margin-left: 4px;
+}
 
+/* --- 수량 조절 + 가격 가로 배치 --- */
+.item-bottom {
+  display: flex;
+  align-items: center;
+  margin-top: 8px;
+  gap: 16px;
+}
+
+.quantity-control {
+  display: flex;
+  align-items: center;
+}
+
+.quantity-btn {
+  width: 28px;
+  height: 28px;
+  font-size: 18px;
+  border: 1px solid #ccc;
+  background: white;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.quantity-number {
+  margin: 0 8px;
+  font-size: 14px;
+}
+
+/* --- 체크박스 --- */
 .item-checkbox-container {
   display: flex;
   align-items: center;
@@ -249,10 +258,58 @@ body {
   font-weight: bold;
 }
 
-.cart-item {
+/* --- 하단 주문하기 구역 --- */
+.order-footer {
+  display: flex;
   justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  border-top: 1px solid #ddd;
+  background-color: #fff;
+  position: sticky;
+  bottom: 0;
 }
 
-.cart-item-details {
-  flex: 1;
+.order-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.order-price {
+  font-size: 18px;
+  font-weight: bold;
+}
+
+.order-guide {
+  font-size: 12px;
+  color: #888;
+  margin-top: 4px;
+}
+
+.order-button {
+  background-color: #2ac1bc;
+  color: white;
+  font-weight: bold;
+  padding: 10px 24px;
+  font-size: 16px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.order-button:hover {
+  background-color: #22a4a0;
+}
+.order-compare-price {
+  font-size: 14px;
+  text-decoration: line-through;
+  color: #555;
+  margin-top: 4px;
+}
+
+.order-saved {
+  font-size: 14px;
+  color: #28a745;
+  font-weight: bold;
+  margin-top: 4px;
 }

--- a/src/style/SavedAmountPage.css
+++ b/src/style/SavedAmountPage.css
@@ -1,0 +1,84 @@
+.saved-page-container {
+    width: 91%;
+    min-height: 90vh;
+    padding: 20px 16px;
+    background: linear-gradient(to bottom, #f9fbfc, #f1f3f5);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.page-title {
+    font-size: 26px;
+    font-weight: 800;
+    margin: 30px 0 20px;
+    color: #222;
+    text-align: center;
+}
+
+.saved-list {
+    width: 100%;
+    background: #ffffff;
+    padding: 20px;
+    border-radius: 14px;
+    box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.08);
+    margin-bottom: 20px;
+}
+
+.saved-list-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 14px 12px;
+    margin-bottom: 10px;
+    background: #f6f8fa;
+    border-radius: 8px;
+    font-size: 15px;
+    color: #444;
+}
+
+.saved-month {
+    font-weight: 600;
+    color: #333;
+}
+
+.saved-amount {
+    font-weight: bold;
+    color: #28a745;
+}
+
+.empty-text {
+    text-align: center;
+    color: #bbb;
+    font-size: 14px;
+}
+
+.saved-back-button {
+    width: 100%;
+    max-width: 400px;
+    padding: 16px;
+    font-size: 17px;
+    font-weight: bold;
+    background-color: #0066ff;
+    color: white;
+    border: none;
+    border-radius: 10px;
+    margin-top: auto;
+    margin-bottom: 20px;
+    box-shadow: 0px 4px 10px rgba(0, 102, 255, 0.4);
+    cursor: pointer;
+    transition: background-color 0.3s, transform 0.2s;
+}
+
+.back-button:hover {
+    background-color: #0052cc;
+    transform: translateY(-2px);
+}
+
+/* 반응형 */
+@media (min-width: 768px) {
+    .saved-page-container {
+        max-width: 480px;
+        margin: 0 auto;
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

> 

## 작업 내용

> 장바구니 상품 수량 추가 및 오프라인/매장 상품과 온라인 가격 비교

> 아이템 상품 component로 만들었습니다.


## 

> 기존 장바구니
![스크린샷 2025-04-27 195825](https://github.com/user-attachments/assets/16d30f1a-4320-418f-b7f1-0fb718233c1b)

> 수량 및 가격 비교 추가
![스크린샷 2025-04-27 212843](https://github.com/user-attachments/assets/686d6203-fdf4-4449-9805-95590e602141)



> 기록 상세페이지
![스크린샷 2025-04-27 223656](https://github.com/user-attachments/assets/100073cc-d098-4fe6-957b-5226486468c2)

>기록 시간 최신 순으로 ( 

![스크린샷 2025-04-27 225745](https://github.com/user-attachments/assets/11676b7b-94b8-4e20-99ac-725bb535e01e)



> 마이페이지에서 "아낀 금액 통계" 누르면 년도 월 별로 아낀 금백 리스트로 보여주기
![스크린샷 2025-04-27 225751](https://github.com/user-attachments/assets/9d3fc66f-2d92-48de-8b23-8465c137989f)


> 디버깅 용으로 카메라 찍지 않고 업로드로 확인할 수 있게 file input 태그 추가 
![스크린샷 2025-04-27 225800](https://github.com/user-attachments/assets/22910116-3919-463c-a5be-6158e1d6dd76)

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

기존 바텀 네비바 기록버튼을 마이페이지의 "최근기록페이지"로 넣고 "체크리스트" 버튼으로 수정했으니 여기에 만들어 주세요
