### PR TITLE
Fix: ComparePage 상품 출력 화면 및 화면 padding/margin 값 css 수정

### DIFF
--- a/src/style/ComparePage.css
+++ b/src/style/ComparePage.css
@@ -1,9 +1,4 @@
 /* 코드 문제있으면 알려주세요(김경민) */
-html,
-body {
-  overflow: auto;
-}
-
 body {
   background-color: #f7f8fa;
 }
@@ -11,7 +6,7 @@ body {
 .compare-container {
   max-width: 540px;
   margin: 0 auto;
-  height: auto;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   background-color: white;
@@ -20,13 +15,13 @@ body {
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
   overflow: hidden;
 
-  @media (max-width: 390px) {
+  /* @media (max-width: 390px) {
     padding: 12px;
   }
 
   @media (max-width: 360px) {
     padding: 10px;
-  }
+  }*/
 }
 
 .path-indicator {
@@ -37,6 +32,7 @@ body {
 
 .home-icon-container {
   padding: 10px;
+  flex-shrink: 0;
 }
 
 .home-link {
@@ -58,18 +54,17 @@ body {
 }
 
 .main-content {
+  display: flex;
+  flex-direction: column;
+  margin: auto;
   padding: 16px;
+  height: 0;
+  overflow: hidden;
+  position: relative;
   text-align: center;
   flex-grow: 1;
-  margin: auto;
-  width: 95%;
-
-  @media (max-width: 375px) {
-    max-width: 280px;
-  }
-  @media (max-width: 360px) {
-    max-width: 260px;
-  }
+  max-width: calc(100% - 10.5px);
+  box-sizing: border-box;
 }
 
 .title {
@@ -80,6 +75,7 @@ body {
   color: #222;
   padding-bottom: 10px;
   border-bottom: 1px solid #eee;
+  flex-shrink: 0;
 }
 
 @keyframes pulse {
@@ -105,6 +101,7 @@ body {
   align-items: center;
   margin-bottom: 30px;
   animation: pulse 3s infinite ease-in-out;
+  flex-shrink: 0;
 }
 
 .money-image {
@@ -117,6 +114,11 @@ body {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  flex-grow: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 5px;
+  margin-bottom: 20px;
 }
 
 @keyframes fadeInUp {
@@ -152,10 +154,13 @@ body {
   justify-content: space-between;
   background-color: white;
   border-radius: 10px;
-  padding: 10px;
+  padding: 1px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
   min-height: 140px; /* ↓ 줄임 */
   height: 140px; /* 고정 높이 추가 */
+  flex-shrink: 0;
+  animation: fadeInUp 0.6s ease-in-out forwards;
+  width: 100%;
 }
 
 .product-item {
@@ -205,7 +210,9 @@ body {
   text-decoration: none;
   transition: color 0.2s ease;
   flex: 1;
-  max-width: calc(100% - 130px);
+  max-width: calc(100% - 70px);
+  min-width: 0; /* 추가 */
+  overflow: hidden; /* 추가 */
 }
 
 .product-description:hover {
@@ -229,7 +236,7 @@ body {
 
 .product-checkbox input {
   position: absolute;
-  width: 100%;
+  width: 50px;
   height: 50px;
   margin: 0;
   opacity: 0;
@@ -273,6 +280,8 @@ body {
   margin-left: 10px;
   text-align: left;
   width: 100%;
+  min-width: 0; /* 추가 */
+  overflow: hidden;
 }
 
 .item-title {
@@ -280,6 +289,15 @@ body {
   font-weight: 500;
   margin-bottom: 5px;
   line-height: 1.3;
+  word-wrap: break-word; /* 추가(긴 단어를 줄바꿈) */
+  word-break: break-word; /* 추가 */
+  overflow-wrap: break-word; /* 추가 */
+  hyphens: auto; /* 추가 */
+  display: -webkit-box; /* 추가 */
+  -webkit-line-clamp: 2; /* 추가 */
+  -webkit-box-orient: vertical; /* 추가 */
+  overflow: hidden; /* 추가 */
+  text-overflow: ellipsis;
 }
 
 .item-price {
@@ -305,6 +323,7 @@ body {
   justify-content: center;
   margin-top: 20px;
   margin-bottom: 10px;
+  flex-shrink: 0;
 }
 .page-button {
   margin: 0 5px;


### PR DESCRIPTION
## 연관된 이슈

## 작업 내용

> 상품 비교페이지 검색시 상품 출력 화면 및 화면 padding/margin 값 css 수정 + 검색 상품 출력시 내부 스크롤로 화면 고정시켜서 상품만 위/아래로 이동할 수 있게

## 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/7e3f0810-c1c2-46ce-94a9-34d7e6964bf3)

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
